### PR TITLE
Fix GS issue for a vanilla install

### DIFF
--- a/redturtle/video/configure.zcml
+++ b/redturtle/video/configure.zcml
@@ -3,7 +3,7 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-	xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="redturtle.video">
 
   <five:registerPackage package="." initialize=".initialize" />
@@ -20,10 +20,10 @@
 
   <configure zcml:condition="installed collective.relateditems">
       <include package="collective.relateditems" />
-	  <class class="redturtle.video.content.rtinternalvideo.RTInternalVideo">
+      <class class="redturtle.video.content.rtinternalvideo.RTInternalVideo">
           <implements interface="collective.relateditems.interfaces.IRelatedItemsEnabledContent"/>
       </class>
-	  <class class="redturtle.video.content.rtremotevideo.RTRemoteVideo">
+      <class class="redturtle.video.content.rtremotevideo.RTRemoteVideo">
           <implements interface="collective.relateditems.interfaces.IRelatedItemsEnabledContent"/>
       </class>
   </configure>
@@ -43,6 +43,7 @@
       description="Various import steps that are not handled by GS import/export handlers."
       handler="redturtle.video.setuphandlers.setupVarious">
       <depends name="catalog"/>
+      <depends name="propertiestool"/>
   </genericsetup:importStep>
 
   <genericsetup:upgradeStep


### PR DESCRIPTION
Can't install into a vanilla site, as setuphandlers has a dependency on the redturtle video properties in portal_properties being created first.
