### PR TITLE
Fix pagetemplate import for Plone 4.3 compatibility.

### DIFF
--- a/redturtle/video/browser/videoembedcode.py
+++ b/redturtle/video/browser/videoembedcode.py
@@ -2,8 +2,12 @@
 
 from zope.interface import implements
 from redturtle.video.interfaces import IVideoEmbedCode
-from zope.app.pagetemplate.viewpagetemplatefile import ViewPageTemplateFile
 
+try:
+    from zope.browserpage import viewpagetemplatefile
+except ImportError:
+    # Plone < 4.1
+    from zope.app.pagetemplate import viewpagetemplatefile
 
 class VideoEmbedCode(object):
     """ VideoEmbedCode

--- a/redturtle/video/browser/view.py
+++ b/redturtle/video/browser/view.py
@@ -4,7 +4,11 @@ from urlparse import urlparse
 from zope.component import getMultiAdapter, ComponentLookupError
 from zope.interface import implements
 
-from zope.app.pagetemplate.viewpagetemplatefile import ViewPageTemplateFile
+try:
+    from zope.browserpage import viewpagetemplatefile
+except ImportError:
+    # Plone < 4.1
+    from zope.app.pagetemplate import viewpagetemplatefile
 
 from Products.Five.browser import BrowserView
 from Products.CMFCore.utils import getToolByName


### PR DESCRIPTION
`zope.app.pagetemplate.viewpagetemplatefile.ViewPageTemplateFile` was moved to `zope.browserpage.viewpagetemplatefile.ViewPageTemplateFile`

`zope.app.pagetemplate` is no longer included in Plone >= 4.3
`zope.browserpage.viewpagetemplatefile` works from Plone >= 4.1
