### PR TITLE
Handle possible not found error in tumbnail retrieve

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle possible not found error in tumbnail retrieve
+  [cekk]
 
 
 1.1.0 (2014-07-11)
@@ -13,7 +14,7 @@ Changelog
 - Fixed Python import for Plone 4.3 (close `#14`__) [bhenker]
 - Named the schemaextender adapter, to be compatible with latests
   collective.flowplayer versions [keul]
-  
+
   __ https://github.com/RedTurtle/redturtle.video/pull/14
 
 - Fix permission to add portlet. Now who can manage portlets can create it [cekk]
@@ -175,7 +176,7 @@ __ http://plone.org/products/redturtle.video/issues/7
 * restored right position for a lot of viewlet manager
   (reverting some changes done in version 0.3.1) [keul]
 * splashscreen image can be used (optionally) as real video splashscreen.
-  Now `plone.app.imaging`__ is required (even without ``plone.app.blob``) [keul] 
+  Now `plone.app.imaging`__ is required (even without ``plone.app.blob``) [keul]
 * added video size fields; video view and embed code now use it [keul]
 * properly registering types in TinyMCE (this close `#5`__) [keul]
 * external video now provides the ``IFlowPlayable`` interface only when linking
@@ -229,4 +230,3 @@ __ http://plone.org/products/redturtle.video/issues/2
 -----------------------
 
 * initial release
-

--- a/redturtle/video/events.py
+++ b/redturtle/video/events.py
@@ -12,7 +12,7 @@ from collective.flowplayer.interfaces import IVideo
 from redturtle.video.metadataextractor import extract
 from redturtle.video.interfaces import IVideoEmbedCode
 from redturtle.video.config import DEFAULT_TIMEOUT
-
+from redturtle.video import logger
 if sys.version_info < (2, 6):
     PLONE4 = False
 else:
@@ -129,11 +129,14 @@ def retrieveThumbnail(object, event):
         The fallback it's on the base adapter that raise the exception.
         """
         return
-
-    if PLONE4:
-        response = urllib2.urlopen(thumb_obj.url, timeout=DEFAULT_TIMEOUT)
-    else:
-        response = urllib2.urlopen(thumb_obj.url)
+    try:
+        if PLONE4:
+            response = urllib2.urlopen(thumb_obj.url, timeout=DEFAULT_TIMEOUT)
+        else:
+            response = urllib2.urlopen(thumb_obj.url)
+    except urllib2.HTTPError as e:
+        logger.exception('Thumbnail not saved. Unable to retrieve thumbnail from "%s" for "%s": %s - %s' % (thumb_obj.url, "/".join(object.getPhysicalPath()), e.code, e.msg))
+        return
 
     object.setImage(response.read())
     field = object.getField('image')

--- a/redturtle/video/tests/test_thumbnail_event.py
+++ b/redturtle/video/tests/test_thumbnail_event.py
@@ -32,6 +32,21 @@ class TestInitializedEvent(TestCase):
         img_from_video = md5.new(f.getImage().data).digest()
         self.assertEqual(plone_italia_png, img_from_video)
 
+    def test_no_image_provided_notfound(self):
+        """
+        what's if we don't found any image?
+        """
+        self.portal.invokeFactory(type_name="RTRemoteVideo",
+                                  id="remote-video-file")
+        f = getattr(self.portal, 'remote-video-file')
+        f.edit(title="A remote file",
+               remoteUrl="http://foo.com/foo")
+        urllib2.urlopen = self.original_urlopen
+        notify(ObjectInitializedEvent(f))
+        self.assertEqual(f.getImage(), "")
+        # re-set custom urlopen
+        urllib2.urlopen = self.custom_urlopen
+
     def test_image_provided(self):
         self.portal.invokeFactory(type_name="RTRemoteVideo",
                                   id="other-remote-video-file")


### PR DESCRIPTION
If the video haven't a thumbnail (it happens to me with a youtube video), now we handle the not found error and returns without saving the thumb